### PR TITLE
support du formattage correct en langue anglaise

### DIFF
--- a/MonNom/master.tex
+++ b/MonNom/master.tex
@@ -1,3 +1,8 @@
+% Default language is set to french
+% Change to enable proper hyphenation of english language
+% Do not remove or your language may be overridden by previous articles in the proceedings.
+\selectlanguage{french} % possible values: french, british, UKenglish, USenglish, english, american
+
 \settitle[Sécurité des trotinettes]{Sécurité des trotinettes : prise de contrôle des roues à distance}
 
 

--- a/_master.tex
+++ b/_master.tex
@@ -26,7 +26,7 @@
 %% modules entre eux.
 %% 
 
-\usepackage[french]{babel}
+\usepackage[french,british,UKenglish,english,USenglish,american]{babel}
 \usepackage[utf8x]{inputenc}
 \usepackage[fit]{truncate}
 \usepackage{xspace}
@@ -150,6 +150,7 @@
 \sloppy
 
 \begin{document}
+\selectlanguage{french}
 
 \pagestyle{empty}
 \frontmatter


### PR DESCRIPTION
Ajout des patterns babel pour l'anglais, ainsi que la sélection de la langue française par défaut dans tous les articles. Il faut la resélectionner à chaque article sinon elle se fera écraser pour le reste des actes par le premier qui la modifiera.