### PR TITLE
Keep only one english variant in babel to remove a warning.

### DIFF
--- a/MonNom/master.tex
+++ b/MonNom/master.tex
@@ -1,7 +1,7 @@
 % Default language is set to french
 % Change to enable proper hyphenation of english language
 % Do not remove or your language may be overridden by previous articles in the proceedings.
-\selectlanguage{french} % possible values: french, british, UKenglish, USenglish, english, american
+\selectlanguage{french} % possible values: french, english
 
 \settitle[Sécurité des trotinettes]{Sécurité des trotinettes : prise de contrôle des roues à distance}
 

--- a/_master-ebook.tex
+++ b/_master-ebook.tex
@@ -36,7 +36,7 @@
 \def\figurename{Figure}
 \def\tablename{Table}
 }
-\usepackage[french,british,UKenglish,english,USenglish,american]{babel}
+\usepackage[french,english]{babel}
 % Bug:
 % babel wrongly warns about Figure/Table captions being possibly wrong in French
 % Since the warning does not apply here (false positive), we can remove it.

--- a/_master.tex
+++ b/_master.tex
@@ -38,7 +38,7 @@
 \def\figurename{Figure}
 \def\tablename{Table}
 }
-\usepackage[french,british,UKenglish,english,USenglish,american]{babel}
+\usepackage[french,english]{babel}
 % Bug:
 % babel wrongly warns about Figure/Table captions being possibly wrong in French
 % Since the warning does not apply here (false positive), we can remove it.


### PR DESCRIPTION
The idea is to simplify the file and to avoid a warning during the compilation.