### PR TITLE
Add usage of the calc TikZ library to the template

### DIFF
--- a/_master.tex
+++ b/_master.tex
@@ -66,6 +66,7 @@
 \usetikzlibrary{patterns}
 \usetikzlibrary{shapes}
 \usetikzlibrary{automata}
+\usetikzlibrary{calc}
 
 
 \usepackage{makeidx}


### PR DESCRIPTION
Pour certaines illustrations, la bibliothèque calc de TikZ permet de créer des ancres supplémentaires à "N%" de la distance entre l'ancre nord est et sud est d'un node, par exemple.

Syntaxe : 
```
\node[minimum height=2em] (MyNode) at (0,0) {Tititoto};
\draw[->] (10,10) -- ($(MyNode.north east)!.3!(MyNode.south east)$);
```

